### PR TITLE
forgot to add vmip to .env in monitoring container

### DIFF
--- a/.github/workflows/deploy-monitoring.yml
+++ b/.github/workflows/deploy-monitoring.yml
@@ -47,6 +47,7 @@ jobs:
             cd ~/monitoring
             echo "GRAFANA_ADMIN_USER=${{ secrets.GRAFANA_ADMIN_USER }}" > .env
             echo "GRAFANA_ADMIN_PASSWORD=${{ secrets.GRAFANA_ADMIN_PASSWORD }}" >> .env
+            echo "VM_IP_1=${{ secrets.VM_IP_1 }}" >> .env
             docker compose pull
             docker compose up -d --remove-orphans
             docker system prune -f


### PR DESCRIPTION
## Description

Prometheus should now read ip of vm1 correctly from .env

## Screenshots (if applicable):

## Additional notes:
